### PR TITLE
Filter getNavigations by query parameters

### DIFF
--- a/src/navigations/createNavigation.js
+++ b/src/navigations/createNavigation.js
@@ -9,6 +9,9 @@ export async function main(event) {
   const params = {
     TableName: process.env.NAVIGATIONS_TABLE_NAME,
     Item: {
+      city: data.user_groups.id,
+      language_recordUid: `${data.lang}#${data.id}`,
+      language: data.lang,
       id: data.id,
       description: data.description,
       items: data.object_list,

--- a/src/navigations/createNavigation.js
+++ b/src/navigations/createNavigation.js
@@ -11,7 +11,7 @@ export async function main(event) {
     Item: {
       id: data.id,
       description: data.description,
-      items: data.items,
+      items: data.object_list,
       name: data.name,
       slug: data.slug,
     },

--- a/src/navigations/getNavigations.js
+++ b/src/navigations/getNavigations.js
@@ -1,12 +1,51 @@
 import handler from '../util/handler';
 import dynamoDb from '../util/dynamodb';
 
-export const main = handler(async () => {
-  const params = {
-    TableName: process.env.NAVIGATIONS_TABLE_NAME,
+export const main = handler(async event => {
+  const { userGroupID: queryCity, lang: queryLanguage } = event.queryStringParameters ?? {};
+
+  let params = { TableName: process.env.NAVIGATIONS_TABLE_NAME };
+  let KeyConditionExpression = '';
+  const ExpressionAttributeValues = {};
+  const ExpressionAttributeNames = {};
+
+  // Return whole table if no query parameters found.
+  if (typeof queryCity == 'undefined' && typeof queryLanguage == 'undefined') {
+    const result = await dynamoDb.scan(params);
+
+    return result.Items;
+  }
+
+  // Filter by Global Secondary Index guideLanguage if only language queried.
+  if (typeof queryCity == 'undefined' && typeof queryLanguage != 'undefined') {
+    params['IndexName'] = 'guideLanguage';
+    KeyConditionExpression += '#language = :queryLanguage';
+    ExpressionAttributeValues[':queryLanguage'] = queryLanguage;
+    ExpressionAttributeNames['#language'] = 'language';
+  }
+
+  // DynamoDB parameters if only city queried.
+  if (typeof queryCity != 'undefined') {
+    KeyConditionExpression += '#city = :queryCity ';
+    ExpressionAttributeValues[':queryCity'] = parseInt(queryCity);
+    ExpressionAttributeNames['#city'] = 'city';
+  }
+
+  // DynamoDB language parameters if city AND language queried.
+  if (typeof queryCity != 'undefined' && typeof queryLanguage != 'undefined') {
+    KeyConditionExpression += ' AND begins_with(#language_recordUid, :queryLanguage)';
+    ExpressionAttributeValues[':queryLanguage'] = queryLanguage;
+    ExpressionAttributeNames['#language_recordUid'] = 'language_recordUid';
+  }
+
+  params = {
+    ...params,
+    KeyConditionExpression,
+    ExpressionAttributeValues,
+    ExpressionAttributeNames,
   };
 
-  const result = await dynamoDb.scan(params);
+  const result = await dynamoDb.query(params);
 
   return result.Items;
 });

--- a/src/navigations/getNavigations.js
+++ b/src/navigations/getNavigations.js
@@ -9,14 +9,14 @@ export const main = handler(async event => {
   const ExpressionAttributeValues = {};
   const ExpressionAttributeNames = {};
 
-  // Return whole table if no query parameters found.
+  // Return all fields if no query parameters found.
   if (typeof queryCity == 'undefined' && typeof queryLanguage == 'undefined') {
     const result = await dynamoDb.scan(params);
 
     return result.Items;
   }
 
-  // Filter by Global Secondary Index guideLanguage if only language queried.
+  // Filter by Global Secondary Index 'guideLanguage' if only language queried.
   if (typeof queryCity == 'undefined' && typeof queryLanguage != 'undefined') {
     params['IndexName'] = 'guideLanguage';
     KeyConditionExpression += '#language = :queryLanguage';
@@ -24,14 +24,14 @@ export const main = handler(async event => {
     ExpressionAttributeNames['#language'] = 'language';
   }
 
-  // DynamoDB parameters if only city queried.
+  // DynamoDB parameters if city queried.
   if (typeof queryCity != 'undefined') {
     KeyConditionExpression += '#city = :queryCity ';
     ExpressionAttributeValues[':queryCity'] = parseInt(queryCity);
     ExpressionAttributeNames['#city'] = 'city';
   }
 
-  // DynamoDB language parameters if city AND language queried.
+  // Append language to city parameters if city AND language queried.
   if (typeof queryCity != 'undefined' && typeof queryLanguage != 'undefined') {
     KeyConditionExpression += ' AND begins_with(#language_recordUid, :queryLanguage)';
     ExpressionAttributeValues[':queryLanguage'] = queryLanguage;

--- a/stacks/StorageService.js
+++ b/stacks/StorageService.js
@@ -11,7 +11,8 @@ export default class StorageStack extends sst.Stack {
 
     this.navigationsTable = new sst.Table(this, 'Navigations', {
       fields: {
-        id: sst.TableFieldType.NUMBER,
+        city: sst.TableFieldType.NUMBER,
+        language_recordUid: sst.TableFieldType.STRING,
       },
       primaryIndex: { partitionKey: 'city', sortKey: 'language_recordUid' },
       globalIndexes: { guideLanguage: { partitionKey: 'language' } },

--- a/stacks/StorageService.js
+++ b/stacks/StorageService.js
@@ -13,7 +13,8 @@ export default class StorageStack extends sst.Stack {
       fields: {
         id: sst.TableFieldType.NUMBER,
       },
-      primaryIndex: { partitionKey: 'id' },
+      primaryIndex: { partitionKey: 'city', sortKey: 'language_recordUid' },
+      globalIndexes: { guideLanguage: { partitionKey: 'language' } },
     });
 
     this.guidegroupsTable = new sst.Table(this, 'Guidegroups', {


### PR DESCRIPTION
Get request can now be filtered by:
- No filter. Returns all navigations).
- City
- Language.
- City and language. Returns intersection of city and language.