### PR TITLE
Handling for deleting a navigation field in DynamoDB

### DIFF
--- a/src/navigations/deleteNavigation.js
+++ b/src/navigations/deleteNavigation.js
@@ -1,0 +1,24 @@
+import handler from '../util/handler';
+import dynamoDb from '../util/dynamodb';
+
+export const main = handler(async event => {
+  const { city: pathParamCity } = event.pathParameters;
+  const { language: pathParamLanguage } = event.pathParameters;
+  const { id: pathParamId } = event.pathParameters;
+
+  console.log(`city ${pathParamCity}, lang ${pathParamLanguage}, id ${pathParamId}`);
+
+  const params = {
+    TableName: process.env.NAVIGATIONS_TABLE_NAME,
+    Key: {
+      city: parseInt(pathParamCity, 10),
+      language_recordUid: `${pathParamLanguage}#${pathParamId}`,
+    },
+  };
+
+  console.log('delete params', params);
+
+  await dynamoDb.delete(params);
+
+  return { body: { status: true } };
+});

--- a/stacks/ApiStack.js
+++ b/stacks/ApiStack.js
@@ -35,6 +35,13 @@ export default class ApiStack extends sst.Stack {
             environment: { tableName: navigationsTable.tableName },
           },
         },
+        'DELETE /navigations/{city}/{language}/{id}': {
+          function: {
+            srcPath: 'src/navigations/',
+            handler: 'deleteNavigation.main',
+            environment: { tableName: navigationsTable.tableName },
+          },
+        },
         // Guidegroups
         'GET /guidegroups': {
           function: {


### PR DESCRIPTION
Handling of delete request to API for navigation.
Requires path parameters city, language and id:
`DELETE /navigations/{city}/{language}/{id}`